### PR TITLE
fix: explicitly disable cache

### DIFF
--- a/graph/dataloader/dataloader.go
+++ b/graph/dataloader/dataloader.go
@@ -38,9 +38,14 @@ func (i *DataLoader) GetUser(userID string) (*model.User, error) {
 func NewDataLoader(db storage.Storage) *DataLoader {
 	// instantiate the user dataloader
 	users := &userBatcher{db: db}
+	// disable caching for this sample repo
+	cache := &dataloader.NoCache{}
 	// return the DataLoader
 	return &DataLoader{
-		userLoader: dataloader.NewBatchedLoader(users.get),
+		userLoader: dataloader.NewBatchedLoader(
+			users.get,
+			dataloader.WithCache(cache),
+		),
 	}
 }
 


### PR DESCRIPTION
Explicitly sets [NoCache](https://pkg.go.dev/github.com/graph-gophers/dataloader#NoCache) option, as caching is outside of the scope of this sample.

resolves #10 